### PR TITLE
Bug fix: Move delete button to outside of form block

### DIFF
--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -96,14 +96,15 @@
     <%= form.submit "Generate a Suggested Breakdown\nof this Task (Powered by AI)", name: "get_ai", class: "btn btn-secondary rounded-pill" %><br>
   </div>
 
-    <%= form.submit button_text %>
-  <% if @task && @task.id %>
-    <%= button_to "Delete", task_path(@task.id), method: :delete, form: { data: {turbo_confirm: "Are you sure?"}}, class: "btn btn-secondary rounded-pill" %>
-  <% else %>
+  <%= form.submit button_text %>
+  <% if !@task || @task.id.nil? %>
     <%= form.submit "Save and Create Another Task", name: "create_another", class: "btn btn-secondary rounded-pill" %>
   <% end %>
 <% end %>
 
+<% if @task && @task.id %>
+  <%= button_to "Delete", task_path(@task.id), method: :delete, form: { data: {turbo_confirm: "Are you sure?"}}, class: "btn btn-secondary rounded-pill" %>
+<% end %>
 
 <p>Mandatory fields marked with a *</p>
   </div>


### PR DESCRIPTION
Form had a bug on the edit/show page where all buttons mapped to the delete action after implementing bootstrap

This branch moves the Delete button to a separate part of the partial. The "Save Changes" and "Generate AI Breakdown" buttons now work appropriately again.